### PR TITLE
ft:made the search_path in the pgsql drive config file to be dynamic instead of defaulting to public

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -74,7 +74,7 @@ return [
             'charset' => 'utf8',
             'prefix' => '',
             'prefix_indexes' => true,
-            'search_path' => 'public',
+            'search_path' => env('DB_SCHEMA', 'public'),
             'sslmode' => 'prefer',
         ],
 


### PR DESCRIPTION
The `search_path` attribute in the pgsql driver in the `config/database.php` was defaulting to public schema when running database migrations. So I've added the `DB_SCHEMA` env attribute to register a user defined schema.

This applies to local development only, for those who choose to use PostgreSQL.